### PR TITLE
Update FacebookOAuth::Client#_post

### DIFF
--- a/lib/facebook_oauth/client.rb
+++ b/lib/facebook_oauth/client.rb
@@ -46,7 +46,7 @@ module FacebookOAuth
       end
 
       def _post(url, params={}, headers={})
-        oauth_response = access_token.post(url, params, headers)
+        oauth_response = access_token.post(url, params)
         puts oauth_response.inspect
         JSON.parse(oauth_response) rescue oauth_response
       end


### PR DESCRIPTION
oauth2 gem have to receive only 2 arguments
# Make a POST request with the Access Token
# 
# @see AccessToken#request

def post(path, opts={}, &block)
  request(:post, path, opts, &block)
end

Exception:

/home/ignar/.rvm/gems/ruby-1.8.7-p334@plat/gems/facebook_oauth-0.2.3/lib/facebook_oauth/client.rb:49:in `post': wrong number of arguments (3 for 2) (ArgumentError)
    from /home/ignar/.rvm/gems/ruby-1.8.7-p334@plat/gems/facebook_oauth-0.2.3/lib/facebook_oauth/client.rb:49:in`_post'
    from /home/ignar/.rvm/gems/ruby-1.8.7-p334@plat/gems/facebook_oauth-0.2.3/lib/facebook_oauth/objects.rb:69:in `send'
    from /home/ignar/.rvm/gems/ruby-1.8.7-p334@plat/gems/facebook_oauth-0.2.3/lib/facebook_oauth/objects.rb:69:in`method_missing'
