### PR TITLE
fix  parameter "user/notifications?include_read=1"

### DIFF
--- a/lib/facebook_oauth/client.rb
+++ b/lib/facebook_oauth/client.rb
@@ -46,8 +46,8 @@ module FacebookOAuth
         @access_token
       end
       
-      def _get(url)
-        oauth_response = access_token.get(url).parsed
+      def _get(url, params={})
+        oauth_response = access_token.get(url, :params => params).parsed
         JSON.parse(oauth_response) rescue oauth_response
       end
 

--- a/lib/facebook_oauth/objects.rb
+++ b/lib/facebook_oauth/objects.rb
@@ -68,7 +68,7 @@ module FacebookOAuth
       if first and first == :create
         @client.send(:_post, "/#{@oid}/#{method.to_s}", params)
       else
-        @client.send(:_get, "/#{@oid}/#{method.to_s}")
+        @client.send(:_get, "/#{@oid}/#{method.to_s}", first)
       end
     end
     


### PR DESCRIPTION
hi

facebook user notifications nead a parameter "include_read".
 (see https://developers.facebook.com/docs/reference/api/user/#notifications )

have a no detail data, with not "include_read"
please merge or refactoring.

sorry, i have not fix "notifications update" yet.

best regards,
