### PR TITLE
add mobile auth window show parameter.

### DIFF
--- a/lib/facebook_oauth/client.rb
+++ b/lib/facebook_oauth/client.rb
@@ -15,7 +15,8 @@ module FacebookOAuth
       client.auth_code.authorize_url(
         :client_id => @application_id,
         :redirect_uri => options[:callback] || @callback,
-        :scope => options[:scope]
+        :scope => options[:scope],
+	:display => options[:display] || "page"
       )
     end
     


### PR DESCRIPTION
I added :display parameter to lib/facebook_oauth/client.rb.
This parameter is showing mobile auth window from Facebook
if you want to show mobile facebook auth window, when execute client.authorize_url, add parameter :display => "touch"
